### PR TITLE
'python -m sphinx' was missing project name and release which only 'python...

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,8 @@
 """rm -rf doc/_generated/; python setup.py build_sphinx -E -a
 """
 
+project = "ewoksdask"
+release = "0.1"
 copyright = "2021, ESRF"
 author = "ESRF"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ exclude =
 [build_sphinx]
 project = ewoksdask
 version = attr: ewoksdask.__version__
-release = 0.1
 source-dir = ./doc
 
 [coverage:run]


### PR DESCRIPTION
***In GitLab by @woutdenolf on Apr 8, 2022, 14:27 GMT+2:***

'python -m sphinx' was missing project name and release which only 'python setup.py build_sphinx' had.

**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksdask/-/merge_requests/30*