### PR TITLE
ewoksci moved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Hidden files
 .*
+!.gitignore
+!.gitlab-ci.yml
+!.readthedocs.yaml
 
 # Byte / compiled / optimized
 *.py[cod]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - project: workflow/ewoks/ewoksci
+  - project: workflow/ewoksadmin/ewoksci
     file: .gitlab-ci-template.yml
 
 test-3.6:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-<a href="https://gitlab.esrf.fr/workflow/ewoks/ewoksci/-/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a>
+<a href="https://gitlab.esrf.fr/workflow/ewoksadmin/ewoksci/-/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a>


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jan 26, 2023, 11:24 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksdask/-/merge_requests/42*