### PR TITLE
importlib is broken in python 3.9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,8 @@ build_sdist:
 
 test_sdist-3.9:
   extends: .test_sdist-3.9
+  variables:
+    PYTEST_WARNINGS: "-W error -W ignore::RuntimeWarning:networkx.utils.backends" # networkx #7372
 
 test_sdist-3.8-win:
   extends: .test_sdist-3.8-win


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 29, 2024, 11:11 GMT+1:***



**Assignees:** @woutdenolf

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksdask/-/merge_requests/52*