### PR TITLE
remove deprecated ewoks_jsonload_hook call

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ package_dir=
 packages=find:
 python_requires = >=3.6
 install_requires = 
-    ewokscore >=0.4.1, !=0.8.0
+    ewokscore >=0.8.1
     dask[distributed] >=2021.3.0
     dask-jobqueue >=0.7.3
     pyyaml !=6.0.2rc1; python_version < "3.8"

--- a/src/ewoksdask/bindings.py
+++ b/src/ewoksdask/bindings.py
@@ -13,7 +13,7 @@ from ewokscore import load_graph
 from ewokscore import execute_graph_decorator
 from ewokscore.inittask import instantiate_task
 from ewokscore.inittask import add_dynamic_inputs
-from ewokscore.graph.serialize import ewoks_jsonload_hook
+from ewokscore.graph.serialize import json_load
 from ewokscore.node import NodeIdType
 from ewokscore.node import get_node_label
 from ewokscore.graph import analysis
@@ -23,7 +23,7 @@ from ewokscore import events
 
 
 def _execute_task(execute_options, *inputs):
-    execute_options = json.loads(execute_options, object_pairs_hook=ewoks_jsonload_hook)
+    execute_options = json_load(execute_options)
 
     dynamic_inputs = dict()
     target_id = execute_options["node_id"]


### PR DESCRIPTION
***In GitLab by @woutdenolf on Sep 14, 2024, 10:44 GMT+2:***



**Assignees:** @woutdenolf

**Reviewers:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksdask/-/merge_requests/61*